### PR TITLE
Time-dependent Envelope

### DIFF
--- a/include/mellotron
+++ b/include/mellotron
@@ -6,6 +6,8 @@
 #include <mellotron_bits/fields/MellotronUnits.hpp>
 #include <mellotron_bits/fields/SalaminTightlyFocused.hpp>
 #include <mellotron_bits/fields/eDipoles.hpp>
+#include <mellotron_bits/driver/Envelope_bones.hpp>
+#include <mellotron_bits/driver/Envelope_meat.hpp>
 #include <mellotron_bits/driver/Particle_bones.hpp>
 #include <mellotron_bits/driver/Particle_meat.hpp>
 #include <mellotron_bits/driver/ParticleObserver_bones.hpp>

--- a/include/mellotron_bits/driver/Envelope_bones.hpp
+++ b/include/mellotron_bits/driver/Envelope_bones.hpp
@@ -1,0 +1,97 @@
+#ifndef ENVELOPE_BONES_HPP
+#define ENVELOPE_BONES_HPP
+
+#include <cmath>
+
+#include "mellotron_bits/common/PhysicalConstants.hpp"
+
+namespace mellotron {
+
+/*!
+ *  \class  Envelope
+ *  \author Francois Fillion-Gourdeau      <francois.fillion@emt.inrs.ca>
+ *  \since  2018-12-21
+ *  \brief  Defines en envelope over the time dependence of the electromagnetic
+ *          field
+ *
+ * This class defines a time-dependent envelope with value in [0,1], that is a
+ * multiplicative function that multiplies the  electromagnetic field. It it used
+ * mostly to guarantee that the field is zero at the initial time. Hopefully,
+ * the implemented envelope models have negligible effect on the spectral
+ * components of the electromagnetic field.
+ */
+
+class Envelope
+{
+public:
+
+  /// Constructor
+  Envelope();
+  /// Destructor
+  ~Envelope();
+
+  /// Function that returns the value of the envelope at time t
+  virtual double Value(double my_t) = 0;
+
+
+protected:
+
+
+};
+
+/*!
+ *  \class  NoEnvelope
+ *  \author Francois Fillion-Gourdeau      <francois.fillion@emt.inrs.ca>
+ *  \since  2018-12-21
+ *  \brief  No envelope, i.e. the value is always one.
+ */
+
+class NoEnvelope : public Envelope
+{
+public:
+
+  /// Constructor
+  NoEnvelope();
+  /// Destructor
+  ~NoEnvelope();
+
+  /// Function that returns the value of the envelope at time t
+  double Value(double my_t);
+
+protected:
+
+};
+
+/*!
+ *  \class  EnvelopeHann
+ *  \author Francois Fillion-Gourdeau      <francois.fillion@emt.inrs.ca>
+ *  \since  2018-12-21
+ *  \brief  Defines an envelope which is a Hann function: g(t) = cos^2(Omega(t-t0))
+ */
+
+class EnvelopeHann : public Envelope
+{
+public:
+
+  /// Constructor that sets the parameter
+  EnvelopeHann(double my_initial_time,
+               double my_total_time);
+  /// Destructor
+  ~EnvelopeHann();
+
+  /// Function that returns the value of the envelope at time t
+  double Value(double my_t);
+
+protected:
+
+  double initial_time;    ///< Initial time of the simulation
+  double total_time;      ///< Total time of the simulation
+  double omega;           ///< Frequency of the cos function
+
+};
+
+
+
+} // namespace mellotron
+
+#endif // ENVELOPE_BONES_HPP

--- a/include/mellotron_bits/driver/Envelope_meat.hpp
+++ b/include/mellotron_bits/driver/Envelope_meat.hpp
@@ -1,0 +1,47 @@
+#ifndef ENVELOPE_MEAT_HPP
+#define ENVELOPE_MEAT_HPP
+
+namespace mellotron {
+
+
+inline
+Envelope::Envelope(){}
+
+inline
+Envelope::~Envelope(){}
+
+
+inline
+NoEnvelope::NoEnvelope(){}
+
+inline
+NoEnvelope::~NoEnvelope(){}
+
+inline
+double NoEnvelope::Value(double my_t){return 1.0;}
+
+
+inline
+EnvelopeHann::EnvelopeHann(double my_initial_time,
+                           double my_total_time)
+: initial_time(my_initial_time)
+, total_time(my_total_time)
+{
+  omega = constants::math::pi/total_time;
+}
+
+inline
+EnvelopeHann::~EnvelopeHann(){}
+
+inline
+double EnvelopeHann::Value(double my_t)
+{
+  double cos_value = std::cos(omega*my_t);
+  return cos_value*cos_value;
+}
+
+
+
+} // namespace mellotron
+
+#endif // ENVELOPE_MEAT_HPP

--- a/include/mellotron_bits/driver/Particle_bones.hpp
+++ b/include/mellotron_bits/driver/Particle_bones.hpp
@@ -4,6 +4,8 @@
 #include <armadillo>
 #include <cmath>
 
+#include "mellotron_bits/driver/Envelope_bones.hpp"
+
 namespace mellotron {
 
 /// enum to choose the radiation reaction model.
@@ -31,6 +33,7 @@ public:
            const double                    my_mass,
                  FieldModel             &  my_field_model,
                  MellotronUnits         &  my_units,
+                 Envelope               &  my_envelope,
            const RadiationReactionModel    my_radiation_reaction = NoRR);
 
   /// Computation of the field tensor at a given point in space-time.
@@ -69,10 +72,12 @@ protected:
 
 
         MellotronUnits           &  unit_system;           ///< Contains information about the unit system used. Useful for RR.
+        Envelope                 &  envelope;              ///< Object that contains the electromagnetic field envelope
   const RadiationReactionModel      radiation_reaction;    ///< Determines the model of radiation reaction we employ, if at all.
 
         double                      chi_sq;                ///< Lorentz invariant along the trajectory, squared.
         double                      chi;                   ///< Lorentz invariant along the trajectory.
+
 };
 
 /*!
@@ -103,6 +108,7 @@ public:
                         FieldModel              &  my_field_model,
                         MellotronUnits          &  my_units,
                         double                     my_field_threshold,
+                        Envelope                &  my_envelope,
                   const RadiationReactionModel     my_radiation_reaction = NoRR);
 
   /// Accessor function to check whether the particle has been "ionized".

--- a/include/mellotron_bits/driver/Particle_meat.hpp
+++ b/include/mellotron_bits/driver/Particle_meat.hpp
@@ -9,11 +9,13 @@ Particle<FieldModel>::Particle(const double                     my_charge,
                                const double                     my_mass,
                                      FieldModel              &  my_field_model,
                                      MellotronUnits          &  my_units,
+                                     Envelope                &  my_envelope,
                                const RadiationReactionModel     my_radiation_reaction)
 : charge(my_charge)
 , mass(my_mass)
 , field_model(my_field_model)
 , unit_system(my_units)
+, envelope(my_envelope)
 , radiation_reaction(my_radiation_reaction)
 {}
 
@@ -27,10 +29,12 @@ Particle<FieldModel>::ComputeFieldTensor(const double t,
 {
   std::array<double,6> field = this->field_model.ComputeFieldComponents(t,x,y,z);
 
+  double value_envelope = envelope.Value(t);
+
   for (uint i=0; i<3; i++)
   {
-    this->electric_field(i) = field[i];
-    this->magnetic_field(i) = field[i+3];
+    this->electric_field(i) = field[i]*value_envelope;
+    this->magnetic_field(i) = field[i+3]*value_envelope;
   }
 }
 
@@ -130,8 +134,9 @@ ParticleIonized<FieldModel>::ParticleIonized(const double                     my
                                                    FieldModel              &  my_field_model,
                                                    MellotronUnits          &  my_units,
                                                    double                     my_field_threshold,
+                                                   Envelope                &  my_envelope,
                                              const RadiationReactionModel     my_radiation_reaction)
-: Particle<FieldModel>(my_charge,my_mass,my_field_model,my_units,my_radiation_reaction)
+: Particle<FieldModel>(my_charge,my_mass,my_field_model,my_units,my_envelope,my_radiation_reaction)
 , field_threshold(my_field_threshold)
 , ApplyLorentzForce(false)
 {}

--- a/simulations/IntegrationStrattoLinearSG.cpp
+++ b/simulations/IntegrationStrattoLinearSG.cpp
@@ -71,6 +71,7 @@ struct StrattoLinearConfig
     double dt_;                   // Duration of a time step
     int nsteps_;                  // Number of time steps
     void read(std::ifstream& file, StrattoLinearConfig*& config);
+    std::string envelope_;
 };
 
 // Function used to read the data read from the config file.
@@ -168,6 +169,7 @@ void StrattoLinearConfig::read(std::ifstream& file, StrattoLinearConfig*& config
             config->t_init_ = v.second.get<double>("t_init");
             config->dt_ = v.second.get<double>("dt");
             config->nsteps_ = v.second.get<int>("nsteps");
+            config->envelope_ = v.second.get("envelope", "NoEnvelope");
         }
     }
 
@@ -341,6 +343,15 @@ int main(int argc, char* argv[])
     config->t_init_ = config->t_init_ / electron_units.UNIT_TIME;
     config->dt_ = config->dt_ / electron_units.UNIT_TIME;
 
+    // Initial time
+    // Behaviour depends on where we read the initial time.
+    double t_init;
+    if (IsConstantInitialTime)
+        t_init = config->t_init_;
+    else
+        t_init = init_conds[6];
+
+
     // MELLOTRON
     // Determine the radiation reaction model.
     mellotron::RadiationReactionModel rr_model;
@@ -356,7 +367,18 @@ int main(int argc, char* argv[])
     else
         rr_model = mellotron::NoRR;
 
-    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units, rr_model);
+    // Create envelope
+    mellotron::Envelope* envelope;
+    if (config->envelope_ == std::string("NoEnvelope"))
+        envelope = new mellotron::NoEnvelope();
+
+    else if (config->envelope_ == std::string("EnvelopeHann"))
+        envelope = new mellotron::EnvelopeHann(t_init,config->nsteps_*config->dt_);
+
+    else
+        envelope = new mellotron::NoEnvelope();
+
+    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units, *envelope, rr_model);
     mellotron::ParticleObserver<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle_obs(particle,config->nsteps_);
 
     // Define the initial conditions.
@@ -370,13 +392,6 @@ int main(int argc, char* argv[])
     double pz_init = init_conds[5];
 
     // Times at which we output the data.
-    // Behaviour depends on where we read the initial time.
-    double t_init;
-    if (IsConstantInitialTime)
-        t_init = config->t_init_;
-    else
-        t_init = init_conds[6];
-
     arma::colvec times = arma::linspace<arma::colvec>(t_init,t_init+config->nsteps_*config->dt_,config->nsteps_); // Time vector
 
     // Set the initial conditions.
@@ -396,6 +411,7 @@ int main(int argc, char* argv[])
     particle_obs.OutputData();
 
 
+    delete envelope;
     delete config;
     return 0;
 

--- a/simulations/IntegrationStrattoLinearSGZernike.cpp
+++ b/simulations/IntegrationStrattoLinearSGZernike.cpp
@@ -74,6 +74,7 @@ struct StrattoLinearConfig
     double dt_;                   // Duration of a time step
     int nsteps_;                  // Number of time steps
     void read(std::ifstream& file, StrattoLinearConfig*& config);
+    std::string envelope_;
 };
 
 // Function used to read the data read from the config file.
@@ -175,6 +176,7 @@ void StrattoLinearConfig::read(std::ifstream& file, StrattoLinearConfig*& config
             config->t_init_ = v.second.get<double>("t_init");
             config->dt_ = v.second.get<double>("dt");
             config->nsteps_ = v.second.get<int>("nsteps");
+            config->envelope_ = v.second.get("envelope", "NoEnvelope");
         }
     }
 
@@ -355,6 +357,13 @@ int main(int argc, char* argv[])
     config->t_init_ = config->t_init_ / electron_units.UNIT_TIME;
     config->dt_ = config->dt_ / electron_units.UNIT_TIME;
 
+    // Behaviour depends on where we read the initial time.
+    double t_init;
+    if (IsConstantInitialTime)
+        t_init = config->t_init_;
+    else
+        t_init = init_conds[6];
+
     // MELLOTRON
     // Determine the radiation reaction model.
     mellotron::RadiationReactionModel rr_model;
@@ -370,7 +379,18 @@ int main(int argc, char* argv[])
     else
         rr_model = mellotron::NoRR;
 
-    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units, rr_model);
+    // Create envelope
+    mellotron::Envelope* envelope;
+    if (config->envelope_ == std::string("NoEnvelope"))
+        envelope = new mellotron::NoEnvelope();
+
+    else if (config->envelope_ == std::string("EnvelopeHann"))
+        envelope = new mellotron::EnvelopeHann(t_init,config->nsteps_*config->dt_);
+
+    else
+        envelope = new mellotron::NoEnvelope();
+
+    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units, *envelope, rr_model);
     mellotron::ParticleObserver<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle_obs(particle,config->nsteps_);
 
     // Define the initial conditions.
@@ -384,13 +404,6 @@ int main(int argc, char* argv[])
     double pz_init = init_conds[5];
 
     // Times at which we output the data.
-    // Behaviour depends on where we read the initial time.
-    double t_init;
-    if (IsConstantInitialTime)
-        t_init = config->t_init_;
-    else
-        t_init = init_conds[6];
-
     arma::colvec times = arma::linspace<arma::colvec>(t_init,t_init+config->nsteps_*config->dt_,config->nsteps_); // Time vector
 
     // Set the initial conditions.
@@ -410,6 +423,7 @@ int main(int argc, char* argv[])
     particle_obs.OutputData();
 
 
+    delete envelope;
     delete config;
     return 0;
 

--- a/simulations/IntegrationStrattoLinearZernike.cpp
+++ b/simulations/IntegrationStrattoLinearZernike.cpp
@@ -72,6 +72,7 @@ struct StrattoLinearConfig
     double dt_;                   // Duration of a time step
     int nsteps_;                  // Number of time steps
     void read(std::ifstream& file, StrattoLinearConfig*& config);
+    std::string envelope_;
 };
 
 // Function used to read the data read from the config file.
@@ -169,6 +170,7 @@ void StrattoLinearConfig::read(std::ifstream& file, StrattoLinearConfig*& config
             config->t_init_ = v.second.get<double>("t_init");
             config->dt_ = v.second.get<double>("dt");
             config->nsteps_ = v.second.get<int>("nsteps");
+            config->envelope_ = v.second.get("envelope", "NoEnvelope");
         }
     }
 
@@ -349,6 +351,14 @@ int main(int argc, char* argv[])
     config->t_init_ = config->t_init_ / electron_units.UNIT_TIME;
     config->dt_ = config->dt_ / electron_units.UNIT_TIME;
 
+    // Initial time
+    // Behaviour depends on where we read the initial time.
+    double t_init;
+    if (IsConstantInitialTime)
+        t_init = config->t_init_;
+    else
+        t_init = init_conds[6];
+
     // MELLOTRON
     // Determine the radiation reaction model.
     mellotron::RadiationReactionModel rr_model;
@@ -364,7 +374,18 @@ int main(int argc, char* argv[])
     else
         rr_model = mellotron::NoRR;
 
-    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units, rr_model);
+    // Create envelope
+    mellotron::Envelope* envelope;
+    if (config->envelope_ == std::string("NoEnvelope"))
+        envelope = new mellotron::NoEnvelope();
+
+    else if (config->envelope_ == std::string("EnvelopeHann"))
+        envelope = new mellotron::EnvelopeHann(t_init,config->nsteps_*config->dt_);
+
+    else
+        envelope = new mellotron::NoEnvelope();
+
+    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units, *envelope, rr_model);
     mellotron::ParticleObserver<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle_obs(particle,config->nsteps_);
 
     // Define the initial conditions.
@@ -378,13 +399,6 @@ int main(int argc, char* argv[])
     double pz_init = init_conds[5];
 
     // Times at which we output the data.
-    // Behaviour depends on where we read the initial time.
-    double t_init;
-    if (IsConstantInitialTime)
-        t_init = config->t_init_;
-    else
-        t_init = init_conds[6];
-
     arma::colvec times = arma::linspace<arma::colvec>(t_init,t_init+config->nsteps_*config->dt_,config->nsteps_); // Time vector
 
     // Set the initial conditions.
@@ -404,6 +418,7 @@ int main(int argc, char* argv[])
     particle_obs.OutputData();
 
 
+    delete envelope;
     delete config;
     return 0;
 

--- a/simulations/IntegrationStrattoMosaic.cpp
+++ b/simulations/IntegrationStrattoMosaic.cpp
@@ -69,6 +69,7 @@ struct StrattoMosaicConfig
     double dt_;                   // Duration of a time step
     int nsteps_;                  // Number of time steps
     void read(std::ifstream& file, StrattoMosaicConfig*& config);
+    std::string envelope_;
 };
 
 // Function used to read the data read from the config file.
@@ -167,6 +168,7 @@ void StrattoMosaicConfig::read(std::ifstream& file, StrattoMosaicConfig*& config
             config->t_init_ = v.second.get<double>("t_init");
             config->dt_ = v.second.get<double>("dt");
             config->nsteps_ = v.second.get<int>("nsteps");
+            config->envelope_ = v.second.get("envelope", "NoEnvelope");
         }
     }
 
@@ -341,8 +343,27 @@ int main(int argc, char* argv[])
     config->t_init_ = config->t_init_ / electron_units.UNIT_TIME;
     config->dt_ = config->dt_ / electron_units.UNIT_TIME;
 
+    // Initial time
+    // Behaviour depends on where we read the initial time.
+    double t_init;
+    if (IsConstantInitialTime)
+        t_init = config->t_init_;
+    else
+        t_init = init_conds[6];
+
+    // Create envelope
+    mellotron::Envelope* envelope;
+    if (config->envelope_ == std::string("NoEnvelope"))
+        envelope = new mellotron::NoEnvelope();
+
+    else if (config->envelope_ == std::string("EnvelopeHann"))
+        envelope = new mellotron::EnvelopeHann(t_init,config->nsteps_*config->dt_);
+
+    else
+        envelope = new mellotron::NoEnvelope();
+
     // MELLOTRON
-    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units);
+    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units,*envelope);
     mellotron::ParticleObserver<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle_obs(particle,config->nsteps_);
 
     // Define the initial conditions.
@@ -356,13 +377,6 @@ int main(int argc, char* argv[])
     double pz_init = init_conds[5];
 
     // Times at which we output the data.
-    // Behaviour depends on where we read the initial time.
-    double t_init;
-    if (IsConstantInitialTime)
-        t_init = config->t_init_;
-    else
-        t_init = init_conds[6];
-
     arma::colvec times = arma::linspace<arma::colvec>(t_init,t_init+config->nsteps_*config->dt_,config->nsteps_); // Time vector
 
     // Set the initial conditions.
@@ -382,6 +396,7 @@ int main(int argc, char* argv[])
     particle_obs.OutputData();
 
 
+    delete envelope;
     delete config;
     return 0;
 

--- a/simulations/IntegrationStrattoMosaicSG.cpp
+++ b/simulations/IntegrationStrattoMosaicSG.cpp
@@ -70,6 +70,7 @@ struct StrattoMosaicConfig
     double dt_;                   // Duration of a time step
     int nsteps_;                  // Number of time steps
     void read(std::ifstream& file, StrattoMosaicConfig*& config);
+    std::string envelope_;
 };
 
 // Function used to read the data read from the config file.
@@ -167,6 +168,7 @@ void StrattoMosaicConfig::read(std::ifstream& file, StrattoMosaicConfig*& config
             config->t_init_ = v.second.get<double>("t_init");
             config->dt_ = v.second.get<double>("dt");
             config->nsteps_ = v.second.get<int>("nsteps");
+            config->envelope_ = v.second.get("envelope", "NoEnvelope");
         }
     }
 
@@ -341,8 +343,27 @@ int main(int argc, char* argv[])
     config->t_init_ = config->t_init_ / electron_units.UNIT_TIME;
     config->dt_ = config->dt_ / electron_units.UNIT_TIME;
 
+    // Initial time
+    // Behaviour depends on where we read the initial time.
+    double t_init;
+    if (IsConstantInitialTime)
+        t_init = config->t_init_;
+    else
+        t_init = init_conds[6];
+
+    // Create envelope
+    mellotron::Envelope* envelope;
+    if (config->envelope_ == std::string("NoEnvelope"))
+        envelope = new mellotron::NoEnvelope();
+
+    else if (config->envelope_ == std::string("EnvelopeHann"))
+        envelope = new mellotron::EnvelopeHann(t_init,config->nsteps_*config->dt_);
+
+    else
+        envelope = new mellotron::NoEnvelope();
+
     // MELLOTRON
-    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units);
+    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units,*envelope);
     mellotron::ParticleObserver<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle_obs(particle,config->nsteps_);
 
     // Define the initial conditions.
@@ -356,13 +377,6 @@ int main(int argc, char* argv[])
     double pz_init = init_conds[5];
 
     // Times at which we output the data.
-    // Behaviour depends on where we read the initial time.
-    double t_init;
-    if (IsConstantInitialTime)
-        t_init = config->t_init_;
-    else
-        t_init = init_conds[6];
-
     arma::colvec times = arma::linspace<arma::colvec>(t_init,t_init+config->nsteps_*config->dt_,config->nsteps_); // Time vector
 
     // Set the initial conditions.
@@ -382,6 +396,7 @@ int main(int argc, char* argv[])
     particle_obs.OutputData();
 
 
+    delete envelope;
     delete config;
     return 0;
 

--- a/simulations/IntegrationStrattoMosaicSGZernike.cpp
+++ b/simulations/IntegrationStrattoMosaicSGZernike.cpp
@@ -72,6 +72,7 @@ struct StrattoMosaicConfig
     double dt_;                   // Duration of a time step
     int nsteps_;                  // Number of time steps
     void read(std::ifstream& file, StrattoMosaicConfig*& config);
+    std::string envelope_;
 };
 
 // Function used to read the data read from the config file.
@@ -171,6 +172,7 @@ void StrattoMosaicConfig::read(std::ifstream& file, StrattoMosaicConfig*& config
             config->t_init_ = v.second.get<double>("t_init");
             config->dt_ = v.second.get<double>("dt");
             config->nsteps_ = v.second.get<int>("nsteps");
+            config->envelope_ = v.second.get("envelope", "NoEnvelope");
         }
     }
 
@@ -352,8 +354,27 @@ int main(int argc, char* argv[])
     config->t_init_ = config->t_init_ / electron_units.UNIT_TIME;
     config->dt_ = config->dt_ / electron_units.UNIT_TIME;
 
+    // Initial time
+    // Behaviour depends on where we read the initial time.
+    double t_init;
+    if (IsConstantInitialTime)
+        t_init = config->t_init_;
+    else
+        t_init = init_conds[6];
+
+    // Create envelope
+    mellotron::Envelope* envelope;
+    if (config->envelope_ == std::string("NoEnvelope"))
+        envelope = new mellotron::NoEnvelope();
+
+    else if (config->envelope_ == std::string("EnvelopeHann"))
+        envelope = new mellotron::EnvelopeHann(t_init,config->nsteps_*config->dt_);
+
+    else
+        envelope = new mellotron::NoEnvelope();
+
     // MELLOTRON
-    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units);
+    mellotron::Particle<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle(config->Q_,config->mass_,*wrapper,electron_units,*envelope);
     mellotron::ParticleObserver<StrattoCalculatorWrapper<StrattonChuIntegrator::MeshlessAxialSurfGenField>> particle_obs(particle,config->nsteps_);
 
     // Define the initial conditions.
@@ -367,13 +388,6 @@ int main(int argc, char* argv[])
     double pz_init = init_conds[5];
 
     // Times at which we output the data.
-    // Behaviour depends on where we read the initial time.
-    double t_init;
-    if (IsConstantInitialTime)
-        t_init = config->t_init_;
-    else
-        t_init = init_conds[6];
-
     arma::colvec times = arma::linspace<arma::colvec>(t_init,t_init+config->nsteps_*config->dt_,config->nsteps_); // Time vector
 
     // Set the initial conditions.
@@ -393,6 +407,7 @@ int main(int argc, char* argv[])
     particle_obs.OutputData();
 
 
+    delete envelope;
     delete config;
     return 0;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,11 @@ include_directories(${GTEST_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${GTEST_LIBRARIES})
 
 # -- Output tests in directory
+add_executable("UnitTest-Envelope" "UnitTest-Envelope.cpp")
+target_link_libraries("UnitTest-Envelope" ${LIBS})
+add_test(NAME "UnitTest-Envelope" COMMAND "UnitTest-Envelope")
+
+
 add_executable("UnitTest-Particle" "UnitTest-Particle.cpp")
 target_link_libraries("UnitTest-Particle" ${LIBS})
 add_test(NAME "UnitTest-Particle" COMMAND "UnitTest-Particle")

--- a/tests/UnitTest-Envelope.cpp
+++ b/tests/UnitTest-Envelope.cpp
@@ -1,0 +1,46 @@
+/*! ------------------------------------------------------------------------- *
+ * \author Francois Fillion-Gourdeau  <francois.fillion@emt.inrs.ca>          *
+ * \since 2018-12-21                                                          *
+ *                                                                            *
+ * Unit test of Envelope in MELLOTRON.                                        *
+ * --------------------------------------------------------------------------*/
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <iomanip>
+#include <limits>
+#include <cmath>
+
+#include <mellotron>
+
+
+
+using namespace mellotron;
+
+TEST(Envelope, NoEnvelope)
+{
+  NoEnvelope env;
+  EXPECT_NEAR(1.0, env.Value(0.0),1.0e-10);
+}
+TEST(Envelope, EnvelopeHann)
+{
+  EnvelopeHann env(-0.5,1.0);
+  EXPECT_NEAR(1.0, env.Value(0.0),1.0e-10);
+  EXPECT_NEAR(0.0, env.Value(0.5),1.0e-10);
+  EXPECT_NEAR(0.0, env.Value(-0.5),1.0e-10);
+  EXPECT_NEAR(0.5, env.Value(0.25),1.0e-10);
+  EXPECT_NEAR(0.5, env.Value(-0.25),1.0e-10);
+}
+
+
+GTEST_API_ int main(int argc, char **argv)
+{
+  H5open();
+  printf("Running main() UnitTest-Particle.cpp.\n");
+  testing::InitGoogleTest(&argc, argv);
+  auto result =  RUN_ALL_TESTS();
+  H5close();
+
+  return result;
+}

--- a/tests/UnitTest-Particle.cpp
+++ b/tests/UnitTest-Particle.cpp
@@ -64,7 +64,7 @@ public:
   : charge(2.0)
   , mass(3.0)
   , electron_units(1.0)
-  , electron(charge,mass,field,electron_units)
+  , electron(charge,mass,field,electron_units,envelope)
   , electron_obs(electron)
   {}
 
@@ -73,6 +73,7 @@ public:
 
   ConstantField                                     field;
   MellotronUnits                                    electron_units;
+  NoEnvelope                                        envelope;
   Particle<ConstantField>                           electron;
   ParticleObserver<ConstantField>                   electron_obs;
 
@@ -217,9 +218,9 @@ public:
   : charge(2.0)
   , mass(3.0)
   , electron_units(1.0)
-  , electron(charge,mass,field,electron_units,0.0)
+  , electron(charge,mass,field,electron_units,0.0,envelope)
   , electron_obs(electron)
-  , electron_below(charge,mass,field,electron_units,10000.0)
+  , electron_below(charge,mass,field,electron_units,10000.0,envelope)
   , electron_obs_below(electron_below)
   {}
 
@@ -228,6 +229,7 @@ public:
 
   ConstantField                                     field;
   MellotronUnits                                    electron_units;
+  NoEnvelope                                        envelope;
   ParticleIonized<ConstantField>                    electron;
   ParticleObserverIonized<ConstantField>            electron_obs;
   ParticleIonized<ConstantField>                    electron_below;

--- a/tests/UnitTest-ParticleObserverLienardWiechert.cpp
+++ b/tests/UnitTest-ParticleObserverLienardWiechert.cpp
@@ -65,7 +65,7 @@ public:
   , number_points_theta(50)
   , number_points_phi(50)
   , electron_units(1.0)
-  , electron(charge,mass,field,electron_units)
+  , electron(charge,mass,field,electron_units,envelope)
   , electron_obs(electron,radius,number_points_theta,number_points_phi,100)
   {}
 
@@ -77,6 +77,7 @@ public:
 
   ConstantField                                     field;
   MellotronUnits                                    electron_units;
+  NoEnvelope                                        envelope;
   Particle<ConstantField>                           electron;
   ParticleObserverLienardWiechert<ConstantField>    electron_obs;
 


### PR DESCRIPTION
These commits implement a new class Envelope that is used to generate a time envelope on the electromagnetic field. Each Envelope model is a function with values varying in time in [0,1]. This functions multiplies the electromagnetic field. The targeted application of the envelope is to ensure that the electromagnetic is zero at the initial time. Right now, there are two envelope models: NoEnvelope and EnvelopeHann (cos squared). Other models can be simply added using inheritance. 